### PR TITLE
Fix app quit shortcut command

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -43,7 +43,7 @@ pub fn get_app_menu(system_menu_translation: SystemMenuTranslation) -> Menu {
   let quit = CustomMenuItem::new(
     QUIT,
     system_menu_translation.sub_menu(QUIT, "Quit OneKeePass"),
-  ).accelerator("CmdOrControl+G");
+  ).accelerator("CmdOrControl+Q");
 
   #[allow(unused_mut)]
   let mut first_menu;


### PR DESCRIPTION
Hi! 
I assume the “G” key to exit an app was added by mistake, at least all macOS apps default to the CMD+Q shortcut.